### PR TITLE
Blocker

### DIFF
--- a/blocker/start/src/background/background.ts
+++ b/blocker/start/src/background/background.ts
@@ -3,11 +3,21 @@
 //   // TODO: on installed function
 // })
 
-chrome.webRequest.onBeforeRequest.addListener((details) => {
-  console.log(details)
-  return {
-    cancel: true,
-  }
-},{
-  urls: [`*;//*.googleadservices.com/*`],
-},["blocking"])
+// chrome.webRequest.onBeforeRequest.addListener((details) => {
+//   const url = details.url
+//   const filters = ["googleadservices", "googlesyndication", "g.doubleclick"]
+//   for(const filter of filters){
+//     if(url.indexOf(filter) != -1){
+//       return {
+//         cancel: true,
+//       }
+//     }
+//   }
+// },{
+//   urls: [
+//     "<all_urls>",
+//     `*://*.googleadservices.com/*`,
+//     `*://*.tpc.googlesyndication.com/*`,
+//     "*://.g.doubleclick.net/*"
+//   ],
+// },["blocking"])

--- a/blocker/start/src/background/background.ts
+++ b/blocker/start/src/background/background.ts
@@ -1,4 +1,13 @@
 // TODO: background script
-chrome.runtime.onInstalled.addListener(() => {
-  // TODO: on installed function
-})
+// chrome.runtime.onInstalled.addListener(() => {
+//   // TODO: on installed function
+// })
+
+chrome.webRequest.onBeforeRequest.addListener((details) => {
+  console.log(details)
+  return {
+    cancel: true,
+  }
+},{
+  urls: [`*;//*.googleadservices.com/*`],
+},["blocking"])

--- a/blocker/start/src/contentScript/contentScript.ts
+++ b/blocker/start/src/contentScript/contentScript.ts
@@ -1,1 +1,27 @@
-// TODO: content script
+const rules: {
+    [url: string]: () => void
+} = {
+    "https://www.nytimes.com/**": // https://www.nytimes.com/section/business
+    filterNYT2,
+}
+
+function filterNYTTechnology(){
+    return
+    const app = document.getElementById("app")
+    const wrapper = document.getElementById("dfp-ad-top")
+    app.removeChild(wrapper)
+}
+
+function filterNYT2(){
+    const divs = document.getElementsByTagName("div")
+    for(const div of divs){
+        if(div.className.indexOf("ad") != -1){
+            div.style.display = "none"
+        }
+    }
+}
+
+if(document.URL in rules){
+    console.log(document.URL)
+    rules[document.URL]()
+}

--- a/blocker/start/src/static/manifest.json
+++ b/blocker/start/src/static/manifest.json
@@ -2,18 +2,24 @@
   "name": "AdBlock Extension",
   "description": "AdBlock extension in TypeScript!",
   "version": "1.0.0",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "icons": {
     "16": "icon.png",
     "48": "icon.png",
     "128": "icon.png"
   },
   "permissions": [
-    "webRequest",
-    "webRequestBlocking",
-    "<all_urls>",
-    "*://*.googleadservices.com/*"
+    "declarativeNetRequest"
   ],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "ruleset_1",
+        "enabled": false,
+        "path": "rules.json"
+      }
+    ]
+  },
   "background": {
     "service_worker": "background.js"
   },

--- a/blocker/start/src/static/manifest.json
+++ b/blocker/start/src/static/manifest.json
@@ -2,26 +2,29 @@
   "name": "AdBlock Extension",
   "description": "AdBlock extension in TypeScript!",
   "version": "1.0.0",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "icons": {
     "16": "icon.png",
     "48": "icon.png",
     "128": "icon.png"
   },
-  "action": {
-    "default_popup": "popup.html",
-    "default_title": "AdBlock Extension",
-    "default_icon": "icon.png"
-  },
-  "permissions": ["storage"],
-  "options_page": "options.html",
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>",
+    "*://*.googleadservices.com/*"
+  ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["contentScript.js"]
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "contentScript.js"
+      ]
     }
   ]
 }

--- a/blocker/start/src/static/rules.json
+++ b/blocker/start/src/static/rules.json
@@ -1,0 +1,43 @@
+[
+    {
+        "id": 1,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "googlesyndication",
+            "resourceTypes": [
+                "image"
+            ]
+        }
+    },
+    {
+        "id": 2,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "doubleclick",
+            "resourceTypes": [
+                "image",
+                "xmlhttprequest"
+            ]
+        }
+    },
+    {
+        "id": 3,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "googleadservices",
+            "resourceTypes": [
+                "image",
+                "xmlhttprequest"
+            ]
+        }
+    }
+]


### PR DESCRIPTION
Blockerの作成
manifest_v_2
**chrome.webRequest.onBeforeRequest.addListener**を使ったリクエスト処理
URLを検知してそのリクエストのみ排除するやり方
広告を入れたいgoogleと広告Blockerの提供者であるエンジニアとの闘い

manifest_V3
contentScriptを利用してdocumentからadを含んだidもしくはclassNameを持ったDOMを排除する